### PR TITLE
Add **kwargs to CreateTrackObject function

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -94,7 +94,7 @@ def SecondMenu(title, offset):
 	return oc
 
 ####################################################################################################
-def CreateTrackObject(url, title, thumb, summary, include_container=False, includeBandwidths=0):
+def CreateTrackObject(url, title, thumb, summary, include_container=False, **kwargs):
 
 	if url.endswith('.mp3'):
 		container = Container.MP3


### PR DESCRIPTION
Some clients will add other variables than `includeBandwidths` to the request. Using **kwargs makes sure we ignore them all.